### PR TITLE
Add Soda Core data quality module

### DIFF
--- a/calidad_de_datos/README.md
+++ b/calidad_de_datos/README.md
@@ -1,0 +1,75 @@
+# Módulo de calidad de datos
+
+Este módulo implementa tests de calidad de datos usando **Soda Core** como ejemplo de una herramienta más genérica para validar la integridad y calidad de los datos en el sistema transaccional.
+
+**Nota importante**: Los tests de calidad de datos del proyecto se implementan principalmente con **dbt**. Este módulo con Soda Core se incluye únicamente como ejemplo de cómo se puede resolver el mismo problema de calidad de datos con herramientas diferentes.
+
+## Archivos del módulo
+
+### `configuration.yml`
+Archivo de configuración que define la conexión a la base de datos Athena.
+
+### `checks.yml`
+Archivo que contiene los tests de calidad de datos escritos en SodaCL. Incluye ejemplos de diferentes tipos de validaciones que replican funcionalidad equivalente a dbt:
+
+- **Tests de integridad**: not_null, unique, referential integrity
+- **Tests de validación**: formatos, rangos, valores válidos
+- **Tests de calidad**: freshness, cross-checks entre tablas
+
+### `requirements.txt`
+Dependencias de Python necesarias para ejecutar Soda Core.
+
+## Uso
+
+### 1. Probar conexión
+Para verificar que la conexión a Athena funciona correctamente:
+
+```bash
+soda test-connection -d staging_dev -c configuration.yml -V
+```
+
+### 2. Ejecutar Tests de calidad
+Para ejecutar todos los checks definidos en el archivo:
+
+```bash
+soda scan -d staging_dev -c configuration.yml checks.yml
+```
+
+## Tipos de Tests Implementados
+
+### Tests de Integridad de Datos
+- **Not Null**: Verifica que campos críticos no sean nulos
+- **Unique**: Valida que claves primarias sean únicas
+- **Referential Integrity**: Verifica integridad referencial entre tablas
+
+### Tests de Validación de Negocio
+- **Format Validation**: Valida formatos de email, fechas, etc.
+- **Value Ranges**: Verifica que valores numéricos estén en rangos válidos
+- **Accepted Values**: Valida que campos categóricos tengan valores permitidos
+
+### Tests de Calidad de Datos
+- **Freshness**: Verifica que los datos se actualicen regularmente
+- **Cross-checks**: Compara conteos entre tablas de staging y raw
+
+## Equivalencia con dbt
+
+Los tests implementados en SodaCL replican funcionalidad equivalente a los tests de dbt:
+
+| SodaCL | dbt |
+|--------|-----|
+| `missing_count(campo) = 0` | `tests: [not_null]` |
+| `duplicate_count(campo) = 0` | `tests: [unique]` |
+| `values in (campo) must exist in tabla` | `relationships: {to: ref('tabla'), field: 'campo'}` |
+| `invalid_count(campo) = 0` con `valid values` | `accepted_values: {values: [...]}` |
+| `freshness(campo) < 1d` | `dbt_utils.expression_is_true` con interval |
+
+## Integración al Pipeline
+
+Al igual que se hizo con **dltHub** y **dbt**, Soda Core se puede dockerizar e incorporar al pipeline de datos para ejecutar tests de calidad de forma automatizada. Esto permitiría:
+
+- Ejecutar tests de calidad como parte del pipeline de CI/CD
+- Integrar validaciones de datos en el flujo de orquestación
+- Generar alertas automáticas cuando se detecten problemas de calidad
+- Mantener un historial de métricas de calidad de datos
+
+La dockerización de Soda Core seguiría un patrón similar al implementado para otras herramientas del proyecto, permitiendo su integración seamless en el ecosistema de datos.

--- a/calidad_de_datos/checks.yml
+++ b/calidad_de_datos/checks.yml
@@ -1,0 +1,51 @@
+# Archivo de checks de calidad de datos usando SodaCL
+# Ejemplos de tests que replican funcionalidad de dbt para demostrar equivalencia
+
+checks for stg_accounts:
+  # Verificar que un campo no sea nulo
+  # Equivalente en dbt: tests: [not_null]
+  - missing_count(id_cuenta) = 0:
+      name: "id_cuenta no puede ser nulo"
+  # Verificar formato de email
+  # Equivalente en dbt: tests: [dbt_utils.expression_is_true: "correo_electronico ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'"]
+  - invalid_count(correo_electronico) = 0:
+      valid format: email
+      name: "correo_electronico debe tener formato válido"
+
+  # Verificar freshness de datos (actualización reciente)
+  # Equivalente en dbt: tests: [dbt_utils.expression_is_true: "fecha_actualizacion >= current_date - interval '1 day'"]
+  # https://docs.soda.io/sodacl-reference/freshness
+  - freshness(fecha_actualizacion) < 1d:
+      name: "Los datos de stg_accounts deben actualizarse diariamente"
+
+checks for stg_subscriptions:
+  # Verificar que un campo sea único
+  # Equivalente en dbt: tests: [unique]
+  - duplicate_count(id_suscripcion) = 0:
+      name: "id_suscripcion debe ser único"
+  # Cross-check. Compara conteo de staging con el de raw
+  - row_count same as subscriptions in raw_dev
+
+checks for stg_accounts_subscription:
+  # Verificar integridad referencial entre tablas
+  # Equivalente en dbt: 
+  # tests:
+  #   - relationships:
+  #       to: ref('stg_accounts')
+  #       field: id_cuenta
+  - values in (id_cuenta) must exist in stg_accounts (id_cuenta):
+      name: "Todas las cuentas en stg_accounts_subscription deben existir en stg_accounts"
+
+checks for stg_contents:
+  # Verificar valores válidos en un campo
+  # Equivalente en dbt: tests: [accepted_values: {values: ['articulo','proyecto','linea_de_tiempo','quiz']}]
+  - invalid_count(tipo_contenido) = 0:
+      valid values: ['articulo','proyecto','linea_de_tiempo','quiz']
+      name: "tipo_contenido debe ser un valor válido"
+
+checks for stg_subscription_payments:
+  # Verificar rango de valores numéricos
+  # Equivalente en dbt: tests: [dbt_utils.expression_is_true: "monto > 0"]
+  - invalid_count(monto) = 0:
+      valid min: 0
+      name: "monto debe ser mayor o igual a 0"

--- a/calidad_de_datos/configuration.yml
+++ b/calidad_de_datos/configuration.yml
@@ -1,0 +1,15 @@
+data_source staging_dev:
+  type: athena
+  profile_name: bruno_especializacion
+  region_name: us-west-2
+  staging_dir: s3://dateneo-temp-us-west-2-375612485931/athena/dev
+  schema: staging_sistema_transaccional_dev
+  work_group: datavision-375612485931
+
+data_source raw_dev:
+  type: athena
+  profile_name: bruno_especializacion
+  region_name: us-west-2
+  staging_dir: s3://dateneo-temp-us-west-2-375612485931/athena/dev
+  schema: raw_datavision_dev
+  work_group: datavision-375612485931

--- a/calidad_de_datos/requirements.txt
+++ b/calidad_de_datos/requirements.txt
@@ -1,0 +1,1 @@
+soda-core-athena==3.5.5


### PR DESCRIPTION
módulo para la validación de calidad de datos utilizando Soda Core como ejemplo. Incluye la configuración para Athena, ejemplos de validaciones que replican funcionalidades de dbt y las dependencias necesarias.