### PR TITLE
Agrego módulos de API y reverse ETL para la integración de datos RFM

### DIFF
--- a/consumo_y_serving/api/Dockerfile
+++ b/consumo_y_serving/api/Dockerfile
@@ -1,0 +1,19 @@
+# Imagen base para AWS Lambda Python
+# La imagen public.ecr.aws/lambda/python:3.11 incluye:
+#    LAMBDA_TASK_ROOT=/var/task
+#    LAMBDA_RUNTIME_DIR=/var/runtime
+#    Otras variables de entorno de Lambda
+FROM public.ecr.aws/lambda/python:3.11
+
+# Copiar archivos de dependencias
+COPY requirements.txt ${LAMBDA_TASK_ROOT}
+
+# Instalar dependencias de Python
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copiar código de la aplicación
+COPY main.py ${LAMBDA_TASK_ROOT}
+COPY lambda_function.py ${LAMBDA_TASK_ROOT}
+
+# Configurar el handler de Lambda
+CMD ["lambda_function.lambda_handler"]

--- a/consumo_y_serving/api/README.md
+++ b/consumo_y_serving/api/README.md
@@ -1,0 +1,43 @@
+# API DataVision
+
+API REST desarrollada con FastAPI para consultas de datos usando Amazon Athena. Esta API está diseñada para desplegarse en AWS API Gateway con AWS Lambda usando una imagen de Docker almacenada en Amazon ECR.
+
+## 🚀 Características
+
+- **FastAPI**: Framework moderno y rápido para APIs REST
+- **Amazon Athena**: Consultas SQL sobre el data lake construido en S3
+- **AWS Lambda**: Ejecución serverless
+- **Docker**: Containerización para despliegue consistente
+- **Amazon ECR**: Registro de contenedores
+- **API Gateway**: Exposición de la API como servicio web
+- **Mangum**: Adaptador para ejecutar FastAPI en Lambda
+
+## 📋 Endpoints disponibles
+
+### Endpoints del sistema
+- `GET /` - Endpoint raíz con mensaje de bienvenida
+- `GET /health` - Verificación de salud de la API
+- `GET /api/v1/status` - Estado detallado de la API y endpoints disponibles
+
+### Endpoints de negocio (análisis RFM)
+- `GET /api/v1/rfm/segmentos` - Obtener segmentos RFM disponibles
+- `GET /api/v1/rfm/cliente/{id_cuenta}` - Obtener datos RFM de un cliente específico
+
+## 🛠️ Tecnologías utilizadas
+
+- **Python 3.11**
+- **FastAPI 0.104.1**
+- **Mangum 0.17.0** (adaptador Lambda)
+- **Boto3 1.34.0** (SDK de AWS)
+- **Pydantic 2.5.0** (validación de datos)
+
+## 📦 Estructura del proyecto
+
+```
+api/
+├── main.py                 # Aplicación principal FastAPI
+├── lambda_function.py      # Handler para AWS Lambda
+├── requirements.txt        # Dependencias de Python
+├── Dockerfile             # Imagen Docker para Lambda
+└── README.md              # Este archivo
+```

--- a/consumo_y_serving/api/lambda_function.py
+++ b/consumo_y_serving/api/lambda_function.py
@@ -1,0 +1,5 @@
+# Este archivo es necesario para que Lambda encuentre el handler
+from main import handler
+
+# Exportar el handler para Lambda
+lambda_handler = handler

--- a/consumo_y_serving/api/main.py
+++ b/consumo_y_serving/api/main.py
@@ -1,0 +1,293 @@
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from mangum import Mangum
+from pydantic import BaseModel
+from typing import List, Optional
+import boto3
+import os
+import json
+
+# Configuración de Athena
+ATHENA_DATABASE = os.getenv("ATHENA_DATABASE", "datavision")
+ATHENA_WORKGROUP = os.getenv("ATHENA_WORKGROUP", "primary")
+ATHENA_OUTPUT_LOCATION = os.getenv("ATHENA_OUTPUT_LOCATION", "s3://dateneo-athena-results-us-west-2-034362074834/")
+
+# Cliente de Athena
+athena_client = boto3.client('athena')
+
+# Modelos Pydantic para las respuestas
+class SegmentoRFM(BaseModel):
+    segmento: str
+    descripcion: str
+    caracteristicas: str
+
+class ClienteRFM(BaseModel):
+    id_cuenta: int
+    email: str
+    nombre: str
+    segmento_rfm_ultimo: str
+    fecha_rfm_ultimo: str
+    segmento_rfm_anterior: str
+    fecha_rfm_anterior: str
+
+class ErrorResponse(BaseModel):
+    error: str
+    message: str
+
+# Crear la aplicación FastAPI
+app = FastAPI(
+    title="DataVision API",
+    description="API para consultas de datos usando Athena",
+    version="1.0.0"
+)
+
+# Configurar CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # En producción, especificar dominios específicos
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/")
+async def root():
+    """Endpoint raíz - Hola mundo"""
+    return {"message": "¡Hola mundo! Bienvenido a la API de DataVision"}
+
+@app.get("/health")
+async def health_check():
+    """Endpoint de salud para verificar que la API está funcionando"""
+    return {"status": "healthy", "service": "datavision-api"}
+
+@app.get("/api/v1/status")
+async def api_status():
+    """Endpoint de estado de la API"""
+    return {
+        "api_version": "1.0.0",
+        "status": "running",
+        "endpoints": [
+            "/",
+            "/health",
+            "/api/v1/status",
+            "/api/v1/rfm/segmentos",
+            "/api/v1/rfm/cliente/{id_cuenta}"
+        ],
+        "features": [
+            "RFM Analysis",
+            "Athena Integration",
+            "OpenAPI Documentation",
+            "CORS Support"
+        ]
+    }
+
+# Funciones auxiliares para Athena
+async def ejecutar_consulta_athena(query: str) -> List[dict]:
+    """Ejecuta una consulta en Athena y retorna los resultados"""
+    try:
+        # Ejecutar la consulta
+        response = athena_client.start_query_execution(
+            QueryString=query,
+            QueryExecutionContext={'Database': ATHENA_DATABASE},
+            ResultConfiguration={'OutputLocation': ATHENA_OUTPUT_LOCATION},
+            WorkGroup=ATHENA_WORKGROUP
+        )
+        
+        query_execution_id = response['QueryExecutionId']
+        
+        # Esperar a que termine la consulta
+        while True:
+            response = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+            status = response['QueryExecution']['Status']['State']
+            
+            if status in ['SUCCEEDED']:
+                break
+            elif status in ['FAILED', 'CANCELLED']:
+                error_reason = response['QueryExecution']['Status'].get('StateChangeReason', 'Unknown error')
+                raise HTTPException(status_code=500, detail=f"Query failed: {error_reason}")
+            
+            # Esperar 1 segundo antes de verificar nuevamente
+            import time
+            time.sleep(1)
+        
+        # Obtener los resultados
+        results = athena_client.get_query_results(QueryExecutionId=query_execution_id)
+        
+        # Procesar los resultados
+        rows = results['ResultSet']['Rows']
+        if len(rows) < 2:  # Menos de 2 filas significa que no hay datos (solo headers)
+            return []
+        
+        # Obtener los nombres de las columnas
+        columns = [col['VarCharValue'] for col in rows[0]['Data']]
+        
+        # Procesar las filas de datos
+        data = []
+        for row in rows[1:]:
+            row_data = {}
+            for i, col in enumerate(row['Data']):
+                value = col.get('VarCharValue', '')
+                # Convertir a tipos apropiados
+                if columns[i] in ['id_cuenta']:
+                    row_data[columns[i]] = int(value) if value else 0
+                else:
+                    row_data[columns[i]] = value
+            data.append(row_data)
+        
+        return data
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error ejecutando consulta: {str(e)}")
+
+# Endpoints de negocio
+
+@app.get("/api/v1/rfm/segmentos", 
+         response_model=List[SegmentoRFM],
+         summary="Obtener segmentos RFM disponibles",
+         description="Retorna la lista de segmentos RFM definidos en el sistema con sus características")
+async def obtener_segmentos_rfm():
+    """
+    Obtiene los segmentos RFM disponibles en el sistema.
+    
+    Los segmentos RFM se basan en:
+    - **Recency**: Días desde la última actividad
+    - **Frequency**: Frecuencia total de actividades
+    - **Monetary**: Valor monetario total gastado
+    
+    Cada segmento tiene características específicas que ayudan a entender el comportamiento del cliente.
+    """
+    segmentos = [
+        SegmentoRFM(
+            segmento="Campeones",
+            descripcion="Clientes con alta recency, frequency y monetary",
+            caracteristicas="R≥4, F≥4, M≥4 - Clientes más valiosos, compran frecuentemente y recientemente"
+        ),
+        SegmentoRFM(
+            segmento="Clientes Leales",
+            descripcion="Clientes con alta recency y altos valores de frequency/monetary",
+            caracteristicas="R≥4, F≥3, M≥3 - Clientes satisfechos que responden bien a promociones"
+        ),
+        SegmentoRFM(
+            segmento="Clientes de Alto Valor",
+            descripcion="Clientes con alta recency y monetary pero baja frequency",
+            caracteristicas="R≥4, M≥4, F<3 - Clientes que gastan mucho pero no frecuentemente"
+        ),
+        SegmentoRFM(
+            segmento="Clientes Potenciales",
+            descripcion="Clientes con alta recency y valores medios de frequency/monetary",
+            caracteristicas="R≥4, F≥2, M≥2 - Clientes con potencial de crecimiento"
+        ),
+        SegmentoRFM(
+            segmento="Nuevos Clientes",
+            descripcion="Clientes muy recientes con baja frequency y monetary",
+            caracteristicas="R=5, F≤2, M≤2 - Clientes nuevos que necesitan ser retenidos"
+        ),
+        SegmentoRFM(
+            segmento="Necesitan Atención",
+            descripcion="Clientes con baja recency pero alta frequency y monetary",
+            caracteristicas="R≤3, F≥4, M≥4 - Clientes valiosos que se están alejando"
+        ),
+        SegmentoRFM(
+            segmento="En Riesgo",
+            descripcion="Clientes con baja recency y valores medios de frequency/monetary",
+            caracteristicas="R≤3, F≥2, M≥2 - Clientes en riesgo de abandono"
+        ),
+        SegmentoRFM(
+            segmento="No se pueden perder",
+            descripcion="Clientes con muy baja recency pero alta frequency y monetary",
+            caracteristicas="R≤2, F≥4, M≥4 - Clientes críticos que necesitan atención inmediata"
+        ),
+        SegmentoRFM(
+            segmento="Clientes Dormidos",
+            descripcion="Clientes con muy baja recency, frequency y monetary",
+            caracteristicas="R≤2, F≤2, M≤2 - Clientes inactivos"
+        ),
+        SegmentoRFM(
+            segmento="Perdidos",
+            descripcion="Clientes con valores muy bajos en todas las métricas",
+            caracteristicas="R=1, F=1, M=1 - Clientes perdidos"
+        ),
+        SegmentoRFM(
+            segmento="Clientes Regulares",
+            descripcion="Clientes que no encajan en las categorías anteriores",
+            caracteristicas="Cualquier otra combinación - Clientes con comportamiento estándar"
+        )
+    ]
+    
+    return segmentos
+
+@app.get("/api/v1/rfm/cliente/{id_cuenta}", 
+         response_model=ClienteRFM,
+         summary="Obtener datos RFM de un cliente específico",
+         description="Retorna los datos RFM completos de un cliente basado en su ID de cuenta")
+async def obtener_cliente_rfm(id_cuenta: int):
+    """
+    Obtiene los datos RFM de un cliente específico.
+    
+    **Parámetros:**
+    - **id_cuenta**: ID único de la cuenta del cliente
+    
+    **Respuesta:**
+    - Datos demográficos del cliente
+    - Segmentación RFM actual y anterior
+    - Scores individuales (Recency, Frequency, Monetary)
+    - Métricas de comportamiento
+    
+    **Ejemplo de uso:**
+    ```
+    GET /api/v1/rfm/cliente/12345
+    ```
+    """
+    query = f"""
+    SELECT 
+        id_cuenta,
+        correo_electronico as email,
+        nombre_cuenta as nombre,
+        segmento_rfm_ultimo,
+        fecha_rfm_ultimo,
+        segmento_rfm_anterior,
+        fecha_rfm_anterior
+    FROM dim_cuentas
+    WHERE id_cuenta = {id_cuenta} and es_actual
+    """
+    
+    try:
+        resultados = await ejecutar_consulta_athena(query)
+        
+        if not resultados:
+            raise HTTPException(status_code=404, detail=f"Cliente con ID {id_cuenta} no encontrado")
+        
+        cliente_data = resultados[0]
+        
+        return ClienteRFM(
+            id_cuenta=cliente_data['id_cuenta'],
+            email=cliente_data['email'],
+            nombre=cliente_data['nombre'],
+            segmento_rfm_ultimo=cliente_data['segmento_rfm_ultimo'],
+            fecha_rfm_ultimo=str(cliente_data['fecha_rfm_ultimo']),
+            segmento_rfm_anterior=cliente_data['segmento_rfm_anterior'],
+            fecha_rfm_anterior=str(cliente_data['fecha_rfm_anterior'])
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error obteniendo datos del cliente: {str(e)}")
+
+# Crear el handler de Mangum para Lambda
+handler = Mangum(app)
+
+# Para desarrollo local (solo si se ejecuta directamente)
+if __name__ == "__main__":
+    try:
+        import uvicorn
+        port = int(os.getenv("PORT", 8000))
+        uvicorn.run(
+            "main:app",
+            host="0.0.0.0",
+            port=port,
+            reload=True
+        )
+    except ImportError:
+        print("uvicorn no está instalado. Instálalo con: pip install uvicorn")
+        print("Ejecutando solo la aplicación FastAPI...")

--- a/consumo_y_serving/api/requirements.txt
+++ b/consumo_y_serving/api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.104.1
+mangum==0.17.0
+boto3==1.34.0
+pydantic==2.5.0
+python-multipart==0.0.6

--- a/consumo_y_serving/reverse_etl/README.md
+++ b/consumo_y_serving/reverse_etl/README.md
@@ -1,0 +1,328 @@
+# Reverse ETL - Carga RFM a CRM
+
+Script de reverse ETL que sincroniza los segmentos RFM desde Amazon Athena hacia HubSpot CRM. Actualiza automáticamente la propiedad `segmento_rfm` en las empresas de HubSpot basándose en los datos más recientes del data warehouse.
+
+## 🚀 ¿Qué hace este script?
+
+Este script implementa un proceso de **reverse ETL** que:
+
+1. **Extrae** datos de segmentación RFM desde Athena (data warehouse)
+2. **Transforma** los datos para mapear cuentas con empresas en HubSpot
+3. **Carga** los segmentos RFM actualizados en HubSpot CRM
+
+### Flujo de datos:
+```
+Athena (Data Warehouse) → Python Script → HubSpot CRM
+     ↓                        ↓              ↓
+Segmentos RFM          Mapeo de datos    Actualización
+actualizados           id_cuenta →       de propiedades
+                       company_id        en empresas
+```
+
+## 🛠️ Tecnologías utilizadas
+
+- **Python 3.8+**
+- **awswrangler 3.13.0** - Conexión con Athena
+- **requests 2.32.4** - API de HubSpot
+- **boto3** - SDK de AWS
+- **pandas** - Manipulación de datos
+
+## 📋 Prerrequisitos
+
+### 1. Configuración de AWS
+- AWS CLI configurado
+- Permisos de Athena (lectura)
+- Perfil de AWS configurado
+
+### 2. Configuración de HubSpot
+- API Key de HubSpot con permisos de escritura
+- Propiedad personalizada `segmento_rfm` creada en HubSpot
+- Propiedad `id_datavision` en empresas para mapeo
+
+### 3. Estructura de datos
+- Tabla `dim_cuentas` en Athena con columnas:
+  - `id_cuenta` (integer)
+  - `segmento_rfm_ultimo` (string)
+  - `es_actual` (boolean)
+
+## ⚙️ Configuración
+
+### Variables de entorno requeridas
+
+Crea un archivo `.env` o configura las siguientes variables:
+
+```bash
+# HubSpot (REQUERIDO)
+HUBSPOT_API_KEY=pat-na1-xxxxx-xxxxx-xxxxx-xxxxx
+HUBSPOT_BASE_URL=https://api.hubapi.com
+
+# AWS Athena
+ATHENA_DATABASE=analytics_datavision_prod
+ATHENA_WORKGROUP=datavision-375612485931
+AWS_REGION=us-west-2
+AWS_PROFILE=bruno_especializacion
+
+# Configuración de procesamiento
+PROCESSING_LIMIT=5
+TEST_ACCOUNT_ID=4
+
+# Configuración de logging
+LOG_LEVEL=INFO
+```
+
+**Nota**: Puedes usar el archivo `env.example` como plantilla. Copia el archivo y renómbralo a `.env`, luego actualiza los valores según tu configuración.
+
+### Configuración del archivo .env
+
+1. **Copiar la plantilla**:
+```bash
+cp env.example .env
+```
+
+2. **Editar el archivo .env** con tus valores reales:
+```bash
+# Editar con tu editor preferido
+nano .env
+# o
+code .env
+# o
+notepad .env
+```
+
+3. **Verificar que el archivo .env esté en el directorio correcto**:
+```
+reverse_etl/
+├── carga_rfm_crm.py
+├── requirements.txt
+├── env.example
+└── .env          ← Este archivo debe estar aquí
+```
+
+### Instalación de dependencias
+
+```bash
+# Instalar dependencias
+pip install -r requirements.txt
+
+# O instalar manualmente
+pip install awswrangler==3.13.0 requests==2.32.4 python-dotenv==1.0.0
+```
+
+## 🚀 Uso del script
+
+### Modo normal (ejecutar actualizaciones)
+
+```bash
+# Ejecutar el script completo (usa PROCESSING_LIMIT del .env)
+python carga_rfm_crm.py
+
+# Con límite específico desde línea de comandos
+python carga_rfm_crm.py limit=10
+
+# Con variables de entorno
+HUBSPOT_API_KEY=tu_api_key python carga_rfm_crm.py
+```
+
+### Modo de prueba (verificar conexiones)
+
+```bash
+# Probar conexiones y mapeo de datos
+python carga_rfm_crm.py test
+
+# Probar con cuenta específica
+TEST_ACCOUNT_ID=123 python carga_rfm_crm.py test
+```
+
+### Ejemplo completo de configuración
+
+1. **Configurar el archivo .env**:
+```bash
+# Copiar plantilla
+cp env.example .env
+
+# Editar con tus valores
+nano .env
+```
+
+2. **Contenido del archivo .env**:
+```bash
+# Configuración de HubSpot
+HUBSPOT_API_KEY=pat-na1-tu-api-key-real-aqui
+HUBSPOT_BASE_URL=https://api.hubapi.com
+
+# Configuración de AWS Athena
+ATHENA_DATABASE=analytics_datavision_prod
+ATHENA_WORKGROUP=datavision-375612485931
+AWS_REGION=us-west-2
+AWS_PROFILE=tu-perfil-aws
+
+# Configuración de procesamiento
+PROCESSING_LIMIT=10
+TEST_ACCOUNT_ID=4
+
+# Configuración de logging
+LOG_LEVEL=INFO
+```
+
+3. **Ejecutar el script**:
+```bash
+# Instalar dependencias
+pip install -r requirements.txt
+
+# Ejecutar en modo de prueba
+python carga_rfm_crm.py test
+
+# Ejecutar actualizaciones
+python carga_rfm_crm.py
+```
+
+## 📊 Funcionalidades
+
+### 1. Extracción de datos desde Athena
+- Consulta la tabla `dim_cuentas` para obtener segmentos RFM actuales
+- Filtra solo registros actuales (`es_actual = true`)
+- Limita resultados para pruebas (configurable)
+
+### 2. Mapeo de cuentas con empresas
+- Busca empresas en HubSpot usando `id_datavision` como identificador
+- Mapea `id_cuenta` de Athena con `company_id` de HubSpot
+
+### 3. Actualización en HubSpot
+- Actualiza la propiedad `segmento_rfm` en empresas existentes
+- Maneja errores de API y registros no encontrados
+- Proporciona logging detallado del proceso
+
+### 4. Modo de prueba
+- Verifica conexión con HubSpot
+- Verifica conexión con Athena
+- Prueba el mapeo de datos entre sistemas
+- Muestra estadísticas de coincidencias
+
+## 📝 Logging y monitoreo
+
+El script genera logs detallados que incluyen:
+
+- **INFO**: Progreso del proceso
+- **DEBUG**: Detalles de mapeo y actualizaciones
+- **WARNING**: Cuentas no encontradas en HubSpot
+- **ERROR**: Errores de conexión o API
+
+### Ejemplo de salida:
+```
+2024-01-15 14:30:00 - INFO - Iniciando proceso de actualización de RFM...
+2024-01-15 14:30:01 - INFO - Obtenidos 5 registros de RFM desde Athena
+2024-01-15 14:30:02 - INFO - Procesando 5 cuentas...
+2024-01-15 14:30:05 - INFO - ==================================================
+2024-01-15 14:30:05 - INFO - RESUMEN DE ACTUALIZACIONES RFM:
+2024-01-15 14:30:05 - INFO - Actualizaciones exitosas: 4
+2024-01-15 14:30:05 - INFO - Actualizaciones fallidas: 0
+2024-01-15 14:30:05 - INFO - Cuentas no encontradas en HubSpot: 1
+2024-01-15 14:30:05 - INFO - Total procesadas: 5
+2024-01-15 14:30:05 - INFO - ==================================================
+```
+
+## 🔧 Configuración avanzada
+
+### Modificar límite de registros
+Para cambiar el límite de registros procesados, puedes:
+
+1. **Usar variable de entorno** (recomendado):
+```bash
+export PROCESSING_LIMIT=10
+python carga_rfm_crm.py
+```
+
+2. **Usar parámetro de línea de comandos**:
+```bash
+python carga_rfm_crm.py limit=10
+```
+
+3. **Modificar el archivo .env**:
+```bash
+PROCESSING_LIMIT=10
+```
+
+### Cambiar propiedades de HubSpot
+Para usar diferentes propiedades, modifica las líneas 72 y 101:
+
+```python
+# Línea 72 - Propiedades a obtener
+'properties': ['id_datavision', 'name', 'segmento_rfm']
+
+# Línea 101 - Propiedad a actualizar
+'segmento_rfm': segmento_rfm
+```
+
+### Configurar logging
+Para cambiar el nivel de logging, puedes:
+
+1. **Usar variable de entorno** (recomendado):
+```bash
+export LOG_LEVEL=DEBUG
+python carga_rfm_crm.py
+```
+
+2. **Modificar el archivo .env**:
+```bash
+LOG_LEVEL=DEBUG
+```
+
+3. **Valores disponibles**: DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+## 🚨 Manejo de errores
+
+El script maneja los siguientes tipos de errores:
+
+1. **Errores de conexión AWS**: Verifica permisos y configuración
+2. **Errores de API HubSpot**: Verifica API key y límites de rate
+3. **Datos no encontrados**: Registra cuentas sin mapeo en HubSpot
+4. **Errores de mapeo**: Identifica problemas de sincronización de datos
+
+## 📈 Métricas y estadísticas
+
+El script proporciona métricas detalladas:
+
+- **Actualizaciones exitosas**: Número de empresas actualizadas correctamente
+- **Actualizaciones fallidas**: Errores en la actualización
+- **Cuentas no encontradas**: Cuentas de Athena sin mapeo en HubSpot
+- **Tasa de coincidencia**: Porcentaje de cuentas mapeadas exitosamente
+
+## 🐛 Troubleshooting
+
+### Problemas con archivo .env
+
+1. **Error "HUBSPOT_API_KEY no está configurada"**:
+   - Verificar que el archivo `.env` existe en el directorio correcto
+   - Verificar que la variable `HUBSPOT_API_KEY` está definida en el archivo
+   - Verificar que no hay espacios alrededor del signo `=`
+
+2. **Variables de entorno no se cargan**:
+   - Verificar que `python-dotenv` está instalado: `pip install python-dotenv`
+   - Verificar que el archivo `.env` está en el mismo directorio que `carga_rfm_crm.py`
+   - Verificar que el archivo `.env` tiene el formato correcto (sin espacios alrededor del `=`)
+
+3. **Archivo .env no encontrado**:
+   - Crear el archivo: `cp env.example .env`
+   - Verificar la ubicación del archivo
+   - Verificar permisos de lectura del archivo
+
+### Problemas comunes de conexión
+
+1. **Error de conexión AWS**:
+   - Verificar configuración de AWS CLI
+   - Comprobar permisos de Athena
+
+2. **Error de API HubSpot**:
+   - Verificar API key válida
+   - Comprobar límites de rate
+
+3. **Cuentas no encontradas**:
+   - Verificar mapeo de `id_datavision`
+   - Comprobar sincronización de datos
+
+4. **Errores de permisos**:
+   - Verificar permisos de escritura en HubSpot
+   - Comprobar permisos de lectura en Athena
+
+
+

--- a/consumo_y_serving/reverse_etl/carga_rfm_crm.py
+++ b/consumo_y_serving/reverse_etl/carga_rfm_crm.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Script de Reverse ETL para cargar segmentos RFM desde Athena a HubSpot.
+Actualiza la propiedad segmento_rfm en las empresas de HubSpot basándose en los datos de Athena.
+"""
+
+import awswrangler as wr
+import requests
+import sys
+import os
+from datetime import datetime
+import logging
+import boto3
+from dotenv import load_dotenv
+
+# Cargar variables de entorno desde archivo .env
+load_dotenv()
+
+# Configuración de logging
+log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level), format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Configuración de HubSpot desde variables de entorno
+HUBSPOT_API_KEY = os.getenv('HUBSPOT_API_KEY')
+HUBSPOT_BASE_URL = os.getenv('HUBSPOT_BASE_URL', 'https://api.hubapi.com')
+
+if not HUBSPOT_API_KEY:
+    logger.error("HUBSPOT_API_KEY no está configurada. Configura esta variable de entorno.")
+    sys.exit(1)
+
+HUBSPOT_HEADERS = {
+    'authorization': f'Bearer {HUBSPOT_API_KEY}',
+    'content-type': 'application/json'
+}
+
+# Configuración de AWS desde variables de entorno
+ATHENA_DATABASE = os.getenv('ATHENA_DATABASE', 'analytics_datavision_prod')
+ATHENA_WORKGROUP = os.getenv('ATHENA_WORKGROUP', 'datavision-375612485931')
+AWS_REGION = os.getenv('AWS_REGION', 'us-west-2')
+AWS_PROFILE = os.getenv('AWS_PROFILE')
+
+def get_athena_rfm_data(limit=None):
+    """
+    Obtiene los datos de RFM desde Athena usando awswrangler.
+    Retorna un DataFrame con id_cuenta y segmento_rfm_ultimo.
+    
+    Args:
+        limit (int, optional): Límite de registros a procesar. Si es None, usa el valor por defecto.
+    """
+    logger.info("Obteniendo datos de RFM desde Athena...")
+    
+    # Usar límite desde variable de entorno o parámetro
+    limit_value = limit or int(os.getenv('PROCESSING_LIMIT', '5'))
+    
+    query = f"""
+    SELECT 
+        id_cuenta,
+        segmento_rfm_ultimo
+    FROM dim_cuentas
+    WHERE es_actual = true
+    AND segmento_rfm_ultimo IS NOT NULL
+    ORDER BY id_cuenta LIMIT {limit_value}
+    """
+    
+    try:
+        # Ejecutar query en Athena
+        df = wr.athena.read_sql_query(
+            sql=query,
+            database=ATHENA_DATABASE,
+            ctas_approach=False,
+            workgroup=ATHENA_WORKGROUP
+        )
+        
+        logger.info(f"Obtenidos {len(df)} registros de RFM desde Athena")
+        return df
+        
+    except Exception as e:
+        logger.error(f"Error obteniendo datos de Athena: {str(e)}")
+        raise
+
+def get_hubspot_company_by_account_id(account_id):
+    """
+    Obtiene una empresa específica de HubSpot usando el id_datavision como identificador.
+    Retorna el company_id si se encuentra, None si no.
+    """
+    try:
+        url = f"{HUBSPOT_BASE_URL}/crm/v3/objects/companies/{account_id}"
+        params = {
+            'idProperty': 'id_datavision',
+            'properties': ['id_datavision', 'name', 'segmento_rfm']
+        }
+        
+        response = requests.get(url, headers=HUBSPOT_HEADERS, params=params)
+        
+        if response.status_code == 200:
+            company_data = response.json()
+            company_id = company_data.get('id')
+            logger.debug(f"Empresa encontrada para cuenta {account_id}: {company_id}")
+            return company_id
+        elif response.status_code == 404:
+            logger.debug(f"Empresa no encontrada para cuenta {account_id}")
+            return None
+        else:
+            logger.error(f"Error obteniendo empresa para cuenta {account_id}: {response.json()}")
+            return None
+            
+    except Exception as e:
+        logger.error(f"Error obteniendo empresa para cuenta {account_id}: {str(e)}")
+        return None
+
+def update_hubspot_company_rfm(company_id, segmento_rfm):
+    """
+    Actualiza la propiedad segmento_rfm de una empresa en HubSpot.
+    """
+    url = f"{HUBSPOT_BASE_URL}/crm/v3/objects/companies/{company_id}"
+    
+    data = {
+        'properties': {
+            'segmento_rfm': segmento_rfm
+        }
+    }
+    
+    try:
+        response = requests.patch(url, headers=HUBSPOT_HEADERS, json=data)
+        
+        if response.status_code == 200:
+            logger.debug(f"Actualizada empresa {company_id} con segmento RFM: {segmento_rfm}")
+            return True
+        else:
+            logger.error(f"Error actualizando empresa {company_id}: {response.json()}")
+            return False
+            
+    except Exception as e:
+        logger.error(f"Error actualizando empresa {company_id}: {str(e)}")
+        return False
+
+def process_rfm_updates(limit=None):
+    """
+    Procesa las actualizaciones de RFM desde Athena a HubSpot.
+    
+    Args:
+        limit (int, optional): Límite de registros a procesar. Si es None, usa el valor por defecto.
+    """
+    logger.info("Iniciando proceso de actualización de RFM...")
+    
+    try:
+        # 1. Obtener datos de RFM desde Athena
+        rfm_df = get_athena_rfm_data(limit)
+        
+        if rfm_df.empty:
+            logger.warning("No se encontraron datos de RFM en Athena")
+            return
+        
+        # 2. Procesar actualizaciones
+        updates_successful = 0
+        updates_failed = 0
+        not_found_in_hubspot = 0
+        
+        logger.info(f"Procesando {len(rfm_df)} cuentas...")
+        
+        for _, row in rfm_df.iterrows():
+            account_id = row['id_cuenta']
+            segmento_rfm = row['segmento_rfm_ultimo']
+            
+            # Buscar empresa en HubSpot usando id_cliente
+            hubspot_company_id = get_hubspot_company_by_account_id(account_id)
+            
+            if hubspot_company_id:
+                # Actualizar empresa en HubSpot
+                if update_hubspot_company_rfm(hubspot_company_id, segmento_rfm):
+                    updates_successful += 1
+                    logger.debug(f"Actualizada cuenta {account_id} -> empresa {hubspot_company_id}")
+                else:
+                    updates_failed += 1
+            else:
+                not_found_in_hubspot += 1
+                logger.warning(f"Cuenta {account_id} no encontrada en HubSpot")
+        
+        # 3. Resumen de resultados
+        logger.info("=" * 50)
+        logger.info("RESUMEN DE ACTUALIZACIONES RFM:")
+        logger.info(f"Actualizaciones exitosas: {updates_successful}")
+        logger.info(f"Actualizaciones fallidas: {updates_failed}")
+        logger.info(f"Cuentas no encontradas en HubSpot: {not_found_in_hubspot}")
+        logger.info(f"Total procesadas: {len(rfm_df)}")
+        logger.info("=" * 50)
+        
+    except Exception as e:
+        logger.error(f"Error en el proceso de actualización: {str(e)}")
+        raise
+
+def test_hubspot_connection():
+    """
+    Prueba la conexión con HubSpot.
+    """
+    logger.info("Probando conexión con HubSpot...")
+    
+    try:
+        url = f"{HUBSPOT_BASE_URL}/crm/v3/objects/companies"
+        params = {'limit': 1}
+        
+        response = requests.get(url, headers=HUBSPOT_HEADERS, params=params)
+        
+        if response.status_code == 200:
+            logger.info("Conexión con HubSpot exitosa")
+            return True
+        else:
+            logger.error(f"Error de conexión con HubSpot: {response.json()}")
+            return False
+            
+    except Exception as e:
+        logger.error(f"Error de conexión con HubSpot: {str(e)}")
+        return False
+
+def test_athena_connection():
+    """
+    Prueba la conexión con Athena.
+    """
+    logger.info("Probando conexión con Athena...")
+    
+    try:
+        # Query simple para probar conexión
+        test_query = "SELECT 1 as test_column"
+        
+        df = wr.athena.read_sql_query(
+            sql=test_query,
+            database=ATHENA_DATABASE,
+            ctas_approach=False  # Query simple, no necesita CTAS
+        )
+        
+        logger.info("Conexión con Athena exitosa")
+        return True
+        
+    except Exception as e:
+        logger.error(f"Error de conexión con Athena: {str(e)}")
+        return False
+
+def test_data_mapping(test_account_id=None):
+    """
+    Prueba el mapeo de datos entre Athena y HubSpot.
+    
+    Args:
+        test_account_id (int, optional): ID de cuenta específico para probar. Si es None, usa el valor por defecto.
+    """
+    logger.info("Probando mapeo de datos...")
+    
+    try:
+        # Usar ID de cuenta específico o valor por defecto
+        account_id_to_test = test_account_id or int(os.getenv('TEST_ACCOUNT_ID', '4'))
+        
+        # Obtener datos de RFM (limitado)
+        rfm_query = f"""
+        SELECT 
+            id_cuenta,
+            segmento_rfm_ultimo
+        FROM dim_cuentas
+        WHERE es_actual = true
+        AND id_cuenta = {account_id_to_test}
+        """
+        
+        rfm_df = wr.athena.read_sql_query(
+            sql=rfm_query,
+            database=ATHENA_DATABASE,
+            ctas_approach=False
+        )
+        
+        # Analizar coincidencias usando búsqueda directa
+        matches = 0
+        no_matches = 0
+        
+        logger.info("Análisis de coincidencias:")
+        for _, row in rfm_df.iterrows():
+            account_id = row['id_cuenta']
+            segmento_rfm = row['segmento_rfm_ultimo']
+            
+            # Buscar empresa directamente por id_cliente
+            hubspot_id = get_hubspot_company_by_account_id(account_id)
+            
+            if hubspot_id:
+                matches += 1
+                logger.info(f"Cuenta {account_id} (RFM: {segmento_rfm}) -> Empresa HubSpot {hubspot_id}")
+            else:
+                no_matches += 1
+                logger.info(f"Cuenta {account_id} (RFM: {segmento_rfm}) -> No encontrada en HubSpot")
+        
+        logger.info(f"Resumen de mapeo:")
+        logger.info(f"Coincidencias: {matches}")
+        logger.info(f"Sin coincidencia: {no_matches}")
+        logger.info(f"Total analizadas: {len(rfm_df)}")
+        if len(rfm_df) > 0:
+            logger.info(f"Tasa de coincidencia: {(matches/len(rfm_df))*100:.1f}%")
+        
+        return matches > 0
+        
+    except Exception as e:
+        logger.error(f"Error en prueba de mapeo: {str(e)}")
+        return False
+
+def main():
+    """
+    Función principal.
+    """
+    logger.info("Iniciando script de carga RFM a CRM...")
+    
+    # Configurar sesión de AWS con variables de entorno
+    session_kwargs = {'region_name': AWS_REGION}
+    if AWS_PROFILE:
+        session_kwargs['profile_name'] = AWS_PROFILE
+    
+    boto3.setup_default_session(**session_kwargs)
+    
+    # Verificar argumentos de línea de comandos
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'test':
+            # Modo de prueba
+            logger.info("Modo de prueba activado")
+            
+            # Probar conexiones
+            hubspot_ok = test_hubspot_connection()
+            athena_ok = test_athena_connection()
+            
+            if hubspot_ok and athena_ok:
+                logger.info("Todas las conexiones funcionan correctamente")
+                
+                # Probar mapeo de datos
+                if test_data_mapping():
+                    logger.info("Mapeo de datos funcionando correctamente")
+                else:
+                    logger.warning("Problemas con el mapeo de datos")
+            else:
+                logger.error("Algunas conexiones fallaron")
+                sys.exit(1)
+        elif sys.argv[1].startswith('limit='):
+            # Modo con límite específico
+            try:
+                limit = int(sys.argv[1].split('=')[1])
+                logger.info(f"Modo con límite de {limit} registros")
+                process_rfm_updates(limit)
+                logger.info("Proceso completado exitosamente")
+            except ValueError:
+                logger.error("Formato de límite inválido. Usa: limit=10")
+                sys.exit(1)
+        else:
+            logger.error("Argumento no reconocido. Usa: test, limit=N o sin argumentos")
+            sys.exit(1)
+    else:
+        # Modo normal - ejecutar actualizaciones
+        try:
+            process_rfm_updates()
+            logger.info("Proceso completado exitosamente")
+        except Exception as e:
+            logger.error(f"Error en el proceso: {str(e)}")
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/consumo_y_serving/reverse_etl/env.example
+++ b/consumo_y_serving/reverse_etl/env.example
@@ -1,0 +1,16 @@
+# Configuración de HubSpot
+HUBSPOT_API_KEY=pat-na1-xxxxx-xxxxx-xxxxx-xxxxx
+HUBSPOT_BASE_URL=https://api.hubapi.com
+
+# Configuración de AWS Athena
+ATHENA_DATABASE=analytics_datavision_prod
+ATHENA_WORKGROUP=datavision-375612485931
+AWS_REGION=us-west-2
+AWS_PROFILE=bruno_especializacion
+
+# Configuración de procesamiento
+PROCESSING_LIMIT=5
+TEST_ACCOUNT_ID=4
+
+# Configuración de logging
+LOG_LEVEL=INFO

--- a/consumo_y_serving/reverse_etl/requirements.txt
+++ b/consumo_y_serving/reverse_etl/requirements.txt
@@ -1,0 +1,3 @@
+awswrangler==3.13.0
+requests==2.32.4
+python-dotenv==1.0.0


### PR DESCRIPTION
Introduce una API REST basada en FastAPI para consultar datos RFM a través de Athena, incluyendo el Dockerfile y la configuración de despliegue en AWS Lambda. Agrega un script de reverse ETL para sincronizar segmentos RFM desde Athena hacia HubSpot CRM, con documentación de soporte, configuración de entorno y dependencias necesarias para ambos módulos.